### PR TITLE
Cherry-pick the remaining pt1.13 commits

### DIFF
--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -37,6 +37,8 @@ _ORDINAL = None
 
 # Default bucket size for all-gather and reduce-scatter
 _ALL_GATHER_REDUCE_SCATTER_BUCKET_CAP_MB = 160
+# Default bucket size for all-reduce
+_ALLREDUCE_BUCKET_CAP_MB = 50
 
 
 def _init_world_size_ordinal():
@@ -1037,13 +1039,59 @@ def reduce_gradients(optimizer, groups=None, pin_layout=True):
   """
   count = xrt_world_size()
   if count > 1:
-    gradients = _fetch_gradients(optimizer)
-    all_reduce(
-        REDUCE_SUM,
-        gradients,
-        scale=1.0 / count,
-        groups=groups,
-        pin_layout=pin_layout)
+    bucket_cap = int(os.getenv('BUCKET_CAP_MB',
+                               _ALLREDUCE_BUCKET_CAP_MB)) * 1024 * 1024
+    # Reverse the gradients list so that we start allreduce from the last layer
+    # onwards. This allows allreduce to trigger as soon as the bucket fills up and
+    # overlap with backward pass.
+    gradients = reversed(_fetch_gradients(optimizer))
+    total = 0
+    tensor_bucket = []
+
+    for grad in gradients:
+      grad_bytes = grad.numel() * grad.element_size()
+
+      # Gradient is larger than bucket_cap, don't bucketize
+      if grad_bytes > bucket_cap:
+        # Flush out previous buckets even if they don't fill up
+        # This maintains the strict reverse ordering
+        if len(tensor_bucket):
+          all_reduce(
+              REDUCE_SUM,
+              tensor_bucket,
+              scale=1.0 / count,
+              groups=groups,
+              pin_layout=pin_layout)
+          total = 0
+          tensor_bucket = []
+        all_reduce(
+            REDUCE_SUM, [grad],
+            scale=1.0 / count,
+            groups=groups,
+            pin_layout=pin_layout)
+        continue
+
+      # Bucketize till the total spills over
+      total += grad_bytes
+      if total > bucket_cap:
+        all_reduce(
+            REDUCE_SUM,
+            tensor_bucket,
+            scale=1.0 / count,
+            groups=groups,
+            pin_layout=pin_layout)
+        total = grad_bytes
+        tensor_bucket = []
+      tensor_bucket.append(grad)
+
+    # Flush the last remaining bucket
+    if len(tensor_bucket):
+      all_reduce(
+          REDUCE_SUM,
+          tensor_bucket,
+          scale=1.0 / count,
+          groups=groups,
+          pin_layout=pin_layout)
 
 
 def optimizer_step(optimizer,

--- a/torch_xla/core/xla_model.py
+++ b/torch_xla/core/xla_model.py
@@ -1,3 +1,7 @@
+from __future__ import print_function
+
+import collections
+import contextlib
 import io
 import itertools
 import logging
@@ -1356,6 +1360,28 @@ def get_rng_state(device=None):
   if device is None:
     device = torch_xla._XLAC._xla_get_default_device()
   return torch_xla._XLAC._xla_get_rng_seed(str(device) if device else '')
+
+
+@contextlib.contextmanager
+def fork_rng(device=None, enabled=True):
+  """
+  Forks the RNG, so that when you return, the RNG is reset to the state that it was previously in.
+  Args:
+    device (string, optional): The device where the RNG state needs to be set. If missing the default device seed will be set.
+    enabled (bool): if ``False``, the RNG is not forked.  This is a convenience argument for easily disabling the context manager without having to delete it and unindent your Python code under it.
+  """
+  if not enabled:
+    yield
+    return
+
+  if device is None:
+    device = torch_xla._XLAC._xla_get_default_device()
+  xla_rng_state = get_rng_state(device=device)
+
+  try:
+    yield
+  finally:
+    set_rng_state(xla_rng_state, device=device)
 
 
 def get_memory_info(device):

--- a/torch_xla/utils/checkpoint.py
+++ b/torch_xla/utils/checkpoint.py
@@ -48,6 +48,7 @@ class CheckpointFunction(torch.autograd.Function):
         "cache_enabled": torch.is_autocast_cache_enabled()
     }
     if preserve_rng_state:
+      ctx.fwd_xla_state = xm.get_rng_state()
       ctx.fwd_cpu_state = torch.get_rng_state()
       # Don't eagerly initialize the cuda context by accident.
       # (If the user intends that the context is initialized later, within their
@@ -105,17 +106,21 @@ class CheckpointFunction(torch.autograd.Function):
       rng_devices = ctx.fwd_gpu_devices
     xm.optimization_barrier_(
         CheckpointFunction._extract_tensors_from_list(inputs + list(args)))
+    # torch.random.fork_rng will handle the cpu and gpu seed
+    # xm.fork_rng will handle the xla device seed
     with torch.random.fork_rng(
         devices=rng_devices, enabled=ctx.preserve_rng_state):
-      if ctx.preserve_rng_state:
-        torch.set_rng_state(ctx.fwd_cpu_state)
-        if ctx.had_cuda_in_fwd:
-          set_device_states(ctx.fwd_gpu_devices, ctx.fwd_gpu_states)
-      detached_inputs = detach_variable(tuple(inputs))
-      with torch.enable_grad(), \
-           torch.cuda.amp.autocast(**ctx.gpu_autocast_kwargs), \
-           torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):
-        outputs = ctx.run_function(*detached_inputs)
+      with xm.fork_rng():
+        if ctx.preserve_rng_state:
+          xm.set_rng_state(ctx.fwd_xla_state)
+          torch.set_rng_state(ctx.fwd_cpu_state)
+          if ctx.had_cuda_in_fwd:
+            set_device_states(ctx.fwd_gpu_devices, ctx.fwd_gpu_states)
+        detached_inputs = detach_variable(tuple(inputs))
+        with torch.enable_grad(), \
+            torch.cuda.amp.autocast(**ctx.gpu_autocast_kwargs), \
+            torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):
+          outputs = ctx.run_function(*detached_inputs)
 
     if isinstance(outputs, torch.Tensor):
       outputs = (outputs,)


### PR DESCRIPTION
Several commits from 1.13 are not yet in pytorch-xla 2.1. This change roll in those listed in https://quip-amazon.com/y1nOAzfCnGi8/Torch-XLA-upstreaming-changes-81323-branching-for-21-on-828#temp:C:CRV7e67c1bc9fc4469a9ec6f9e4a .

1. [Gradient bucketing using a pre-defined bucket size cap](https://code.amazon.com/packages/KaenaPyTorchXLAIntegrationDev/commits/fb584844e2c48ad94c05715e3e02767a9e7fbfd5#) . Amith to upstream.
2. [Correctly saving and restoring torch/xla rng state](https://code.amazon.com/packages/KaenaPyTorchXLAIntegrationDev/commits/513227b5549a740146c13192fc9df1394475ff7b#) . Amith/Fei to upstream.
3. [Allgather Reduction Optimization in FSDP](https://code.amazon.com/packages/KaenaPyTorchXLAIntegrationDev/commits/1fc0034c2734d71b62dbef735fb5e3cb777603c7#)  (FSDP, already rolled into [Use reduce-scatter coalescing for FSDP #6024](https://github.com/pytorch/xla/pull/6024))